### PR TITLE
Adjust separator line thickness

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_BASE_URL=https://prolog-api.profy.dev

--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
    Adjusted the profject-card border top thickness to 1px to match the figma design specifications.